### PR TITLE
Work around for large builds.

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -180,7 +180,10 @@ class DashboardPlugin {
           value: {
             errors: stats.hasErrors(),
             warnings: stats.hasWarnings(),
-            data: stats.toJson()
+            // This can break when you're build it TOOO large.
+            // data: stats.toJson()
+            // Skip it for now. Yay!
+            data: {errors:[],warnings:[]}
           }
         },
         {


### PR DESCRIPTION
This allows us to work around the size of the ASAPP monolith build when working with `webpack-dashboard` in the development environment.